### PR TITLE
Improve Claude CLI detection logic and update Gemini CLI error message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,9 +48,9 @@ check_requirements() {
     local claude_location=""
     
     # First check if claude command exists (handles PATH and aliases)
-    if which claude &> /dev/null; then
+    if command -v claude &> /dev/null; then
         claude_found=true
-        claude_location=$(which claude)
+        claude_location=$(command -v claude)
     # Check common installation locations
     elif [ -x "$HOME/.claude/local/claude" ]; then
         claude_found=true


### PR DESCRIPTION
This pull request improves the robustness of the `check_requirements` function in `install.sh` by enhancing the detection logic for the Claude CLI and updating the error message for the Gemini CLI. 

Enhancements to CLI detection:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL46-R73): Improved the detection logic for the Claude CLI by checking multiple potential installation locations (`$HOME/.claude/local/claude`, `/usr/local/bin/claude`, `/opt/homebrew/bin/claude`) in addition to the `PATH` and aliases. The script now logs the exact location of the Claude CLI if found.

Error message updates:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL46-R73): Updated the error message for the Gemini CLI to point to the correct repository URL (`https://github.com/google-gemini/gemini-cli`).