### PR TITLE
fix: Gemini CLI ignores stdin in -p mode — use workspace temp file

### DIFF
--- a/hooks/config/debug.conf
+++ b/hooks/config/debug.conf
@@ -14,7 +14,7 @@ DRY_RUN=false
 
 # Gemini-specific configuration
 GEMINI_CACHE_TTL=3600        # 1 hour cache
-GEMINI_TIMEOUT=30            # 30 seconds timeout
+GEMINI_TIMEOUT=90            # 90 seconds timeout (Gemini needs to read temp file + analyze)
 GEMINI_RATE_LIMIT=1          # 1 second between calls
 GEMINI_MAX_FILES=20          # Max 20 files per call
 


### PR DESCRIPTION
## Summary
- Gemini CLI v0.27.3 does not read piped stdin content when using `-p` mode
- Replaced `echo content | gemini -p "prompt"` with a workspace temp file approach: write concatenated file contents to `.gemini_bridge_analysis_*.txt`, then instruct Gemini to read it via `-y -p "Read <file>..."`
- Fixed Windows path doubling: `D:/` style paths were not detected as absolute, causing `prepare_files_for_gemini()` to prepend the working directory again
- Increased timeout from 30s to 90s (Gemini needs time for file read + analysis)

## Test plan
- [x] 10/10 unit tests pass (`test-runner.sh`)
- [x] End-to-end test with 5 real files (124KB) — Gemini reads temp file and returns correct analysis
- [x] Temp file is cleaned up after execution
- [x] Fallback to normal tool execution on Gemini failure still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)